### PR TITLE
Fixed 32-bit build compilation error

### DIFF
--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -75,7 +75,7 @@ impl LsbWriter {
     /// Buffer n number of bits, and write them to the vec if there are enough pending bits.
     pub fn write_bits(&mut self, v: u16, n: u8) {
         // NOTE: This outputs garbage data if n is 0, but v is not 0
-        self.acc |= (u64::from(v)) << self.bits;
+        self.acc |= (AccType::from(v)) << self.bits;
         self.bits += n;
         // Waiting until we have FLUSH_AT bits and pushing them all in one batch.
         while self.bits >= FLUSH_AT {
@@ -87,7 +87,7 @@ impl LsbWriter {
 
     fn write_bits_finish(&mut self, v: u16, n: u8) {
         // NOTE: This outputs garbage data if n is 0, but v is not 0
-        self.acc |= (u64::from(v)) << self.bits;
+        self.acc |= (AccType::from(v)) << self.bits;
         self.bits += n % 8;
         while self.bits >= 8 {
             self.w.push(self.acc as u8);


### PR DESCRIPTION
On a 32 bit system rust runs into a compilation error:
```
error[E0308]: mismatched types
  --> src/bitstream.rs:78:21
   |
78 |         self.acc |= (u64::from(v)) << self.bits;
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u32, found u64
error[E0277]: no implementation for `u32 |= u64`
  --> src/bitstream.rs:78:18
   |
78 |         self.acc |= (u64::from(v)) << self.bits;
   |                  ^^ no implementation for `u32 |= u64`
   |
   = help: the trait `std::ops::BitOrAssign<u64>` is not implemented for `u32`
```

This pull request fixes that.