### PR TITLE
Fix various spelling errors and details

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Build Status](https://travis-ci.org/image-rs/deflate-rs.svg)](https://travis-ci.org/image-rs/deflate-rs)[![Crates.io](https://img.shields.io/crates/v/deflate.svg)](https://crates.io/crates/deflate)[![Docs](https://docs.rs/deflate/badge.svg)](https://docs.rs/deflate)
 
 
-An implementation of a [DEFLATE](http://www.gzip.org/zlib/rfc-deflate.html) encoder in pure rust. Not a direct port, but does take some inspiration from [zlib](http://www.zlib.net/), [miniz](https://github.com/richgel999/miniz) and [zopfli](https://github.com/google/zopfli). The API is based on the one in the [flate2](https://crates.io/crates/flate2) crate that contains bindings, zlib miniz_oxide, and miniz.
+An implementation of a [DEFLATE](http://www.gzip.org/zlib/rfc-deflate.html) encoder in pure Rust. Not a direct port, but does take some inspiration from [zlib](http://www.zlib.net/), [miniz](https://github.com/richgel999/miniz) and [zopfli](https://github.com/google/zopfli). The API is based on the one in the [flate2](https://crates.io/crates/flate2) crate that contains bindings, zlib miniz_oxide, and miniz.
 
 Deflate encoding with and without zlib and gzip metadata (zlib dictionaries are not supported) is supported. No unsafe code is used.
 
-This library is now mostly in maintainance mode, focus being on the rust-backend of [flate2](https://crates.io/crates/flate2) instead.
+This library is now mostly in maintenance mode, focus being on the Rust backend of [flate2](https://crates.io/crates/flate2) instead.
 
 # Usage:
 ## Simple compression function:
@@ -32,11 +32,11 @@ encoder.write_all(data).unwrap();
 let compressed_data = encoder.finish().unwrap();
 ```
 
-# Other deflate/zlib rust projects from various people
-* [flate2](http://alexcrichton.com/flate2-rs/flate2/index.html) FLATE, Gzip, and Zlib bindings for Rust - can use miniz_oxide for a full rust-implemented library.
+# Other deflate/zlib Rust projects from various people
+* [flate2](http://alexcrichton.com/flate2-rs/flate2/index.html) FLATE, Gzip, and Zlib bindings for Rust - can use miniz_oxide for a pure Rust implementation.
 * [Zopfli in Rust](https://github.com/carols10cents/zopfli) Rust port of zopfli
-* [inflate](https://github.com/PistonDevelopers/inflate) DEFLATE decoder implemented in rust
-* [miniz-oxide](https://github.com/Frommi/miniz_oxide) Port of miniz to rust.
+* [inflate](https://github.com/PistonDevelopers/inflate) DEFLATE decoder implemented in Rust
+* [miniz-oxide](https://github.com/Frommi/miniz_oxide) Port of miniz to Rust.
 * [libflate](https://github.com/sile/libflate) Another DEFLATE/Zlib/Gzip encoder and decoder written in Rust. (Only does some very light compression).
 
 # License

--- a/src/compression_options.rs
+++ b/src/compression_options.rs
@@ -52,7 +52,7 @@ impl Default for Compression {
 pub enum SpecialOptions {
     /// Compress normally.
     Normal,
-    /// Force fixed huffman tables. (Unimplemented!).
+    /// Force fixed Huffman tables. (Unimplemented!).
     _ForceFixed,
     /// Force stored (uncompressed) blocks only. (Unimplemented!).
     _ForceStored,
@@ -90,7 +90,7 @@ pub struct CompressionOptions {
     ///
     /// Higher values degrade compression slightly, but improve compression speed.
     ///
-    /// * `0`: Never lazy match. (Same effect as setting MatchingType to greedy, but may be slower).
+    /// * `0`: Never lazy match. (Same effect as setting `MatchingType` to greedy, but may be slower).
     /// * `1...257`: Only check for a better match if the first match was shorter than this value.
     /// * `258`: Always lazy match.
     ///
@@ -122,7 +122,7 @@ pub struct CompressionOptions {
 // Some standard profiles for the compression options.
 // Ord should be implemented at some point, but won't yet until the struct is stabilised.
 impl CompressionOptions {
-    /// Returns compression settings rouhgly corresponding to the `HIGH(9)` setting in miniz.
+    /// Returns compression settings roughly corresponding to the `HIGH(9)` setting in miniz.
     pub fn high() -> CompressionOptions {
         CompressionOptions {
             max_hash_checks: HIGH_MAX_HASH_CHECKS,
@@ -135,7 +135,7 @@ impl CompressionOptions {
     /// Returns  a fast set of compression settings
     ///
     /// Ideally this should roughly correspond to the `FAST(1)` setting in miniz.
-    /// However, that setting makes miniz use a somewhat different algorhithm,
+    /// However, that setting makes miniz use a somewhat different algorithm,
     /// so currently hte fast level in this library is slower and better compressing
     /// than the corresponding level in miniz.
     pub fn fast() -> CompressionOptions {
@@ -148,7 +148,7 @@ impl CompressionOptions {
     }
 
     /// Returns a set of compression settings that makes the compressor only compress using
-    /// huffman coding. (Ignoring any length/distance matching)
+    /// Huffman coding. (Ignoring any length/distance matching)
     ///
     /// This will normally have the worst compression ratio (besides only using uncompressed data),
     /// but may be the fastest method in some cases.
@@ -166,7 +166,7 @@ impl CompressionOptions {
     ///
     /// This is very fast, but tends to compress worse than looking for more matches using hash
     /// chains that the slower settings do.
-    /// Works best on data that has runs of equivialent bytes, like binary or simple images,
+    /// Works best on data that has runs of equivalent bytes, like binary or simple images,
     /// less good for text.
     pub fn rle() -> CompressionOptions {
         CompressionOptions {

--- a/src/deflate_state.rs
+++ b/src/deflate_state.rs
@@ -68,11 +68,11 @@ pub struct DeflateState<W: Write> {
     pub lz77_state: LZ77State,
     pub input_buffer: InputBuffer,
     pub compression_options: CompressionOptions,
-    /// State the huffman part of the compression and the output buffer.
+    /// State the Huffman part of the compression and the output buffer.
     pub encoder_state: EncoderState,
     /// The buffer containing the raw output of the lz77-encoding.
     pub lz77_writer: DynamicWriter,
-    /// Buffers used when generating huffman code lengths.
+    /// Buffers used when generating Huffman code lengths.
     pub length_buffers: LengthBuffers,
     /// Total number of bytes consumed/written to the input buffer.
     pub bytes_written: u64,

--- a/src/encoder_state.rs
+++ b/src/encoder_state.rs
@@ -19,14 +19,14 @@ pub enum BType {
     DynamicHuffman = 0b10, // Reserved = 0b11, //Error
 }
 
-/// A struct wrapping a writer that writes data compressed using the provided huffman table
+/// A struct wrapping a writer that writes data compressed using the provided Huffman table
 pub struct EncoderState {
     pub huffman_table: HuffmanTable,
     pub writer: LsbWriter,
 }
 
 impl EncoderState {
-    /// Creates a new encoder state using the provided huffman table and writer
+    /// Creates a new encoder state using the provided Huffman table and writer
     pub fn new(writer: Vec<u8>) -> EncoderState {
         EncoderState {
             huffman_table: HuffmanTable::empty(),
@@ -35,7 +35,7 @@ impl EncoderState {
     }
 
     #[cfg(test)]
-    /// Creates a new encoder state using the fixed huffman table
+    /// Creates a new encoder state using the fixed Huffman table
     pub fn fixed(writer: Vec<u8>) -> EncoderState {
         EncoderState {
             huffman_table: HuffmanTable::fixed_table(),

--- a/src/huffman_lengths.rs
+++ b/src/huffman_lengths.rs
@@ -14,16 +14,16 @@ use crate::stored_block::MAX_STORED_BLOCK_LENGTH;
 
 use std::cmp;
 
-// The minimum number of literal/length values
+/// The minimum number of literal/length values
 pub const MIN_NUM_LITERALS_AND_LENGTHS: usize = 257;
-// The minimum number of distances
+/// The minimum number of distances
 pub const MIN_NUM_DISTANCES: usize = 1;
 
 const NUM_HUFFMAN_LENGTHS: usize = 19;
 
-// The output ordering of the lengths for the huffman codes used to encode the lengths
-// used to build the full huffman tree for length/literal codes.
-// http://www.gzip.org/zlib/rfc-deflate.html#dyn
+/// The output ordering of the lengths for the Huffman codes used to encode the lengths
+/// used to build the full Huffman tree for length/literal codes.
+/// http://www.gzip.org/zlib/rfc-deflate.html#dyn
 const HUFFMAN_LENGTH_ORDER: [u8; NUM_HUFFMAN_LENGTHS] = [
     16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15,
 ];
@@ -33,7 +33,7 @@ const HLIT_BITS: u8 = 5;
 const HDIST_BITS: u8 = 5;
 const HCLEN_BITS: u8 = 4;
 
-// The longest a huffman code describing another huffman length can be
+/// The longest a Huffman code describing another Huffman length can be
 const MAX_HUFFMAN_CODE_LENGTH: usize = 7;
 
 // How many bytes (not including padding and the 3-bit block type) the stored block header takes up.
@@ -46,7 +46,7 @@ pub fn remove_trailing_zeroes<T: From<u8> + PartialEq>(input: &[T], min_length: 
     &input[0..cmp::max(input.len() - num_zeroes, min_length)]
 }
 
-/// How many extra bits the huffman length code uses to represent a value.
+/// How many extra bits the Huffman length code uses to represent a value.
 fn extra_bits_for_huffman_length_code(code: u8) -> u8 {
     match code {
         16..=17 => 3,
@@ -55,7 +55,7 @@ fn extra_bits_for_huffman_length_code(code: u8) -> u8 {
     }
 }
 
-/// Calculate how many bits the huffman-encoded huffman lengths will use.
+/// Calculate how many bits the Huffman-encoded Huffman lengths will use.
 fn calculate_huffman_length(frequencies: &[FrequencyType], code_lengths: &[u8]) -> u64 {
     frequencies
         .iter()
@@ -72,7 +72,7 @@ fn calculate_huffman_length(frequencies: &[FrequencyType], code_lengths: &[u8]) 
 ///
 /// Parameters:
 /// Frequencies, length of dynamic codes, and a function to get how many extra bits in addition
-/// to the length of the huffman code the symbol will use.
+/// to the length of the Huffman code the symbol will use.
 fn calculate_block_length<F>(
     frequencies: &[FrequencyType],
     dyn_code_lengths: &[u8],
@@ -155,12 +155,12 @@ pub enum BlockType {
 pub struct DynamicBlockHeader {
     /// Length of the run-length encoding symbols.
     pub huffman_table_lengths: Vec<u8>,
-    /// Number of lengths for values describing the huffman table that encodes the length values
-    /// of the main huffman tables.
+    /// Number of lengths for values describing the Huffman table that encodes the length values
+    /// of the main Huffman tables.
     pub used_hclens: usize,
 }
 
-/// Generate the lengths of the huffman codes we will be using, using the
+/// Generate the lengths of the Huffman codes we will be using, using the
 /// frequency of the different symbols/lengths/distances, and determine what block type will give
 /// the shortest representation.
 /// TODO: This needs a test
@@ -286,7 +286,7 @@ pub fn gen_huffman_lengths(
     }
 }
 
-/// Write the specified huffman lengths to the bit writer
+/// Write the specified Huffman lengths to the bit writer
 pub fn write_huffman_lengths(
     header: &DynamicBlockHeader,
     huffman_table: &HuffmanTable,

--- a/src/input_buffer.rs
+++ b/src/input_buffer.rs
@@ -52,7 +52,7 @@ impl InputBuffer {
 
     /// Slide the input window and add new data.
     ///
-    /// Returns a slice containing the data that did not fit, or None if all data was consumed.
+    /// Returns a slice containing the data that did not fit, or `None` if all data was consumed.
     pub fn slide<'a>(&mut self, data: &'a [u8]) -> Option<&'a [u8]> {
         // This should only be used when the buffer is full
         assert!(self.buffer.len() > WINDOW_SIZE * 2);

--- a/src/length_encode.rs
+++ b/src/length_encode.rs
@@ -2,7 +2,7 @@ use std::clone::Clone;
 use std::iter::Iterator;
 
 /// An enum representing the different types in the run-length encoded data used to encode
-/// huffman table lengths
+/// Huffman table lengths
 #[derive(Debug, PartialEq, Eq)]
 pub enum EncodedLength {
     // An actual length value
@@ -73,13 +73,12 @@ where
 }
 
 /// Run-length encodes the lengths of the values in `lengths` according to the deflate
-/// specification. This is used for writing the code lengths for the huffman tables for
+/// specification. This is used for writing the code lengths for the Huffman tables for
 /// the deflate stream.
 ///
-/// Returns a tuple containing a vec of the encoded lengths
 /// Populates the supplied array with the frequency of the different encoded length values
 /// The frequency array is taken as a parameter rather than returned to avoid
-/// excessive memcpying.
+/// excessive `memcpy`-ing.
 pub fn encode_lengths_m<'a, I>(
     lengths: I,
     mut out: &mut Vec<EncodedLength>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! An implementation an encoder using [DEFLATE](http://www.gzip.org/zlib/rfc-deflate.html)
-//! compression algorightm in pure rust.
+//! compression algorithm in pure Rust.
 //!
 //! This library provides functions to compress data using the DEFLATE algorithm,
 //! optionally wrapped using the [zlib](https://tools.ietf.org/html/rfc1950) or
@@ -8,15 +8,15 @@
 //! like zlib and miniz.
 //!
 //! The deflate algorithm is an older compression algorithm that is still widely used today,
-//! by e.g html headers, the `.png` inage format, the unix `gzip` program and commonly in `.zip`
+//! by e.g html headers, the `.png` image format, the Unix `gzip` program and commonly in `.zip`
 //! files. The `zlib` and `gzip` formats are wrappers around DEFLATE-compressed data, containing
 //! some extra metadata and a checksum to validate the integrity of the raw data.
 //!
-//! The deflate algorithm does not perform as well as newer algorhitms used in file formats such as
+//! The deflate algorithm does not perform as well as newer algorithms used in file formats such as
 //! `.7z`, `.rar`, `.xz` and `.bz2`, and is thus not the ideal choice for applications where
 //! the `DEFLATE` format (with or without wrappers) is not required.
 //!
-//! Support for the gzip wrapper (the wrapper that is used in `.gz` files) is disabled by default,
+//! Support for the gzip wrapper (the wrapper that is used in `.gz` files) is disabled by default
 //! but can be enabled with the `gzip` feature.
 //!
 //! As this library is still in development, the compression output may change slightly

--- a/src/output_writer.rs
+++ b/src/output_writer.rs
@@ -6,7 +6,7 @@ use crate::huffman_table::{
 };
 use crate::lzvalue::LZValue;
 
-/// The type used for representing how many times a literal, length or distance code has been ouput
+/// The type used for representing how many times a literal, length or distance code has been output
 /// to the current buffer.
 /// As we are limiting the blocks to be at most 2^16 bytes long, we can represent frequencies using
 /// 16-bit values.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -61,7 +61,7 @@ pub fn compress_until_done<W: Write>(
 
 /// A DEFLATE encoder/compressor.
 ///
-/// A struct implementing a [`Write`] interface that takes unencoded data and compresses it to
+/// A struct implementing a [`Write`] interface that takes arbitrary data and compresses it to
 /// the provided writer using DEFLATE compression.
 ///
 /// # Examples
@@ -155,7 +155,7 @@ impl<W: Write> Drop for DeflateEncoder<W> {
 
 /// A Zlib encoder/compressor.
 ///
-/// A struct implementing a [`Write`] interface that takes unencoded data and compresses it to
+/// A struct implementing a [`Write`] interface that takes arbitrary data and compresses it to
 /// the provided writer using DEFLATE compression with Zlib headers and trailers.
 ///
 /// # Examples
@@ -302,7 +302,7 @@ pub mod gzip {
 
     /// A Gzip encoder/compressor.
     ///
-    /// A struct implementing a [`Write`] interface that takes unencoded data and compresses it to
+    /// A struct implementing a [`Write`] interface that takes arbitrary data and compresses it to
     /// the provided writer using DEFLATE compression with Gzip headers and trailers.
     ///
     /// # Examples
@@ -343,7 +343,7 @@ pub mod gzip {
         }
 
         /// Create a new GzEncoder from the provided `GzBuilder`. This allows customising
-        /// the detalis of the header, such as the filename and comment fields.
+        /// the details of the header, such as the filename and comment fields.
         pub fn from_builder<O: Into<CompressionOptions>>(
             builder: GzBuilder,
             writer: W,
@@ -398,7 +398,7 @@ pub mod gzip {
             w
         }
 
-        /// Resets the encoder (excelt the compression options), replacing the current writer
+        /// Resets the encoder (except the compression options), replacing the current writer
         /// with a new one, returning the old one, and using the provided `GzBuilder` to
         /// create the header.
         pub fn reset_with_builder(&mut self, writer: W, builder: GzBuilder) -> io::Result<W> {
@@ -426,7 +426,7 @@ pub mod gzip {
                 .write_all(temp.into_inner())
         }
 
-        /// Get the crc32 checksum of the data comsumed so far.
+        /// Get the crc32 checksum of the data consumed so far.
         pub fn checksum(&self) -> u32 {
             self.checksum.sum()
         }
@@ -536,7 +536,7 @@ mod test {
     }
 
     #[test]
-    /// Check if the the result of compressing after resetting is the same as before.
+    /// Check if the result of compressing after resetting is the same as before.
     fn writer_reset() {
         let data = get_test_data();
         let mut compressor = DeflateEncoder::new(


### PR DESCRIPTION
Various notables where I'm open to discussion, if necessary.

* Promoted a few normal comments to doc comments. This was not done where the comment subjectively applied to multiple items.
* Change `unencoded data` to `arbitrary data` in the stream documentation. I don't think the adjective use is very common and this avoids giving the impression that the input has to fulfill some invariants.
