### PR TITLE
Add support for specifying zlib windowBits

### DIFF
--- a/src/compression_options.rs
+++ b/src/compression_options.rs
@@ -19,6 +19,8 @@ pub const MAX_HASH_CHECKS: u16 = 32 * 1024;
 pub const DEFAULT_MAX_HASH_CHECKS: u16 = 128;
 pub const DEFAULT_LAZY_IF_LESS_THAN: u16 = 32;
 
+pub const DEFAULT_WINDOW_BITS: u8 = 15;
+
 /// An enum describing the level of compression to be used by the encoder
 ///
 /// Higher compression ratios will take longer to encode.
@@ -66,6 +68,7 @@ impl Default for SpecialOptions {
 
 pub const DEFAULT_OPTIONS: CompressionOptions = CompressionOptions {
     max_hash_checks: DEFAULT_MAX_HASH_CHECKS,
+    window_bits: DEFAULT_WINDOW_BITS,
     lazy_if_less_than: DEFAULT_LAZY_IF_LESS_THAN,
     matching_type: MatchingType::Lazy,
     special: SpecialOptions::Normal,
@@ -85,7 +88,14 @@ pub struct CompressionOptions {
     ///
     /// Default value: `128`
     pub max_hash_checks: u16,
-    // pub _window_size: u16,
+
+    /// The window_bits parameter is the base two logarithm of the window size
+    /// (the size of the history buffer). It should be in the range 8..15 for
+    /// this version of the library. Larger values of this parameter
+    /// result in better compression at the expense of memory usage.
+    /// The default value is 15 if deflateInit is used instead. 
+    pub window_bits: u8,
+
     /// Only lazy match if we have a length less than this value.
     ///
     /// Higher values degrade compression slightly, but improve compression speed.
@@ -126,6 +136,7 @@ impl CompressionOptions {
     pub fn high() -> CompressionOptions {
         CompressionOptions {
             max_hash_checks: HIGH_MAX_HASH_CHECKS,
+            window_bits: DEFAULT_WINDOW_BITS,
             lazy_if_less_than: HIGH_LAZY_IF_LESS_THAN,
             matching_type: MatchingType::Lazy,
             special: SpecialOptions::Normal,
@@ -141,6 +152,7 @@ impl CompressionOptions {
     pub fn fast() -> CompressionOptions {
         CompressionOptions {
             max_hash_checks: 1,
+            window_bits: DEFAULT_WINDOW_BITS,
             lazy_if_less_than: 0,
             matching_type: MatchingType::Greedy,
             special: SpecialOptions::Normal,
@@ -155,6 +167,7 @@ impl CompressionOptions {
     pub fn huffman_only() -> CompressionOptions {
         CompressionOptions {
             max_hash_checks: 0,
+            window_bits: DEFAULT_WINDOW_BITS,
             lazy_if_less_than: 0,
             matching_type: MatchingType::Greedy,
             special: SpecialOptions::Normal,
@@ -171,10 +184,17 @@ impl CompressionOptions {
     pub fn rle() -> CompressionOptions {
         CompressionOptions {
             max_hash_checks: 0,
+            window_bits: DEFAULT_WINDOW_BITS,
             lazy_if_less_than: 0,
             matching_type: MatchingType::Lazy,
             special: SpecialOptions::Normal,
         }
+    }
+
+    pub fn with_window_bits(self, window_bits: u8) -> CompressionOptions {
+        let mut options = self.clone();
+        options.window_bits = window_bits;
+        options
     }
 }
 

--- a/src/compression_options.rs
+++ b/src/compression_options.rs
@@ -9,6 +9,7 @@
 //! of compression for the provided data.
 //!
 use crate::lz77::MatchingType;
+use crate::zlib::DEFAULT_WINDOW_BITS;
 use std::convert::From;
 
 pub const HIGH_MAX_HASH_CHECKS: u16 = 1768;
@@ -18,8 +19,6 @@ pub const HIGH_LAZY_IF_LESS_THAN: u16 = 128;
 pub const MAX_HASH_CHECKS: u16 = 32 * 1024;
 pub const DEFAULT_MAX_HASH_CHECKS: u16 = 128;
 pub const DEFAULT_LAZY_IF_LESS_THAN: u16 = 32;
-
-pub const DEFAULT_WINDOW_BITS: u8 = 15;
 
 /// An enum describing the level of compression to be used by the encoder
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,12 +185,14 @@ pub fn deflate_bytes(input: &[u8]) -> Vec<u8> {
 pub fn deflate_bytes_zlib_conf<O: Into<CompressionOptions>>(input: &[u8], options: O) -> Vec<u8> {
     use byteorder::WriteBytesExt;
     let mut writer = Vec::with_capacity(input.len() / 3);
+
+    let options = options.into();
     // Write header
-    zlib::write_zlib_header(&mut writer, zlib::CompressionLevel::Default)
+    zlib::write_zlib_header(&mut writer, options.window_bits, zlib::CompressionLevel::Default)
         .expect("Write error when writing zlib header!");
 
     let mut checksum = checksum::Adler32Checksum::new();
-    compress_data_dynamic(input, &mut writer, &mut checksum, options.into())
+    compress_data_dynamic(input, &mut writer, &mut checksum, options)
         .expect("Write error when writing compressed data!");
 
     let hash = checksum.current_hash();

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -227,7 +227,7 @@ impl<W: Write> ZlibEncoder<W> {
     /// Check if a zlib header should be written.
     fn check_write_header(&mut self) -> io::Result<()> {
         if !self.header_written {
-            write_zlib_header(self.deflate_state.output_buf(), CompressionLevel::Default)?;
+            write_zlib_header(self.deflate_state.output_buf(), crate::compression_options::DEFAULT_WINDOW_BITS, CompressionLevel::Default)?;
             self.header_written = true;
         }
         Ok(())

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -8,7 +8,7 @@ use crate::compress::compress_data_dynamic_n;
 use crate::compress::Flush;
 use crate::compression_options::CompressionOptions;
 use crate::deflate_state::DeflateState;
-use crate::zlib::{write_zlib_header, CompressionLevel};
+use crate::zlib::{write_zlib_header, CompressionLevel, DEFAULT_WINDOW_BITS};
 
 const ERR_STR: &str = "Error! The wrapped writer is missing.\
                        This is a bug, please file an issue.";
@@ -227,7 +227,7 @@ impl<W: Write> ZlibEncoder<W> {
     /// Check if a zlib header should be written.
     fn check_write_header(&mut self) -> io::Result<()> {
         if !self.header_written {
-            write_zlib_header(self.deflate_state.output_buf(), crate::compression_options::DEFAULT_WINDOW_BITS, CompressionLevel::Default)?;
+            write_zlib_header(self.deflate_state.output_buf(), DEFAULT_WINDOW_BITS, CompressionLevel::Default)?;
             self.header_written = true;
         }
         Ok(())

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -69,7 +69,7 @@ mod test {
 
     #[test]
     fn test_gen_fcheck() {
-        let cmf = get_zlib_cmf(DEFAULT_CM, 7);
+        let cmf = get_zlib_cmf(DEFAULT_CM, DEFAULT_WINDOW_BITS - 8);
         let flg = super::add_fcheck(
             cmf,
             CompressionLevel::Default as u8 | super::DEFAULT_FDICT,
@@ -79,7 +79,7 @@ mod test {
 
     #[test]
     fn test_header() {
-        let header = get_zlib_header(15, CompressionLevel::Fastest);
+        let header = get_zlib_header(DEFAULT_WINDOW_BITS, CompressionLevel::Fastest);
         assert_eq!(
             ((usize::from(header[0]) * 256) + usize::from(header[1])) % 31,
             0

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -11,7 +11,8 @@
 use std::io::{Result, Write};
 
 // CM = 8 means to use the DEFLATE compression method.
-const DEFAULT_CM: u8 = 8;
+pub(crate) const DEFAULT_CM: u8 = 8;
+pub(crate) const DEFAULT_WINDOW_BITS: u8 = 15;
 
 // No dict by default.
 #[cfg(test)]


### PR DESCRIPTION
This adds support for specifying zlib windowBits parameter in `CompressionOptions` via the `with_window_bits` function.

Example using default compression and windowBits of 10:

```Rust
let deflated_data = deflate::deflate_bytes_zlib_conf(data,
    deflate::CompressionOptions::default().with_window_bits(10)
);
```