### PR TITLE
Remove byteorder dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ exclude = [
 
 [dependencies]
 adler32 = "1.0.4"
-byteorder = "1"
 gzip-header = { version = "0.3", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@ extern crate test as test_std;
 extern crate miniz_oxide;
 
 extern crate adler32;
-extern crate byteorder;
 #[cfg(feature = "gzip")]
 extern crate gzip_header;
 
@@ -87,9 +86,6 @@ mod zlib;
 use std::io;
 use std::io::Write;
 
-use byteorder::BigEndian;
-#[cfg(feature = "gzip")]
-use byteorder::LittleEndian;
 #[cfg(feature = "gzip")]
 use gzip_header::Crc;
 #[cfg(feature = "gzip")]
@@ -184,7 +180,6 @@ pub fn deflate_bytes(input: &[u8]) -> Vec<u8> {
 /// # let _ = compressed_data;
 /// ```
 pub fn deflate_bytes_zlib_conf<O: Into<CompressionOptions>>(input: &[u8], options: O) -> Vec<u8> {
-    use byteorder::WriteBytesExt;
     let mut writer = Vec::with_capacity(input.len() / 3);
     // Write header
     zlib::write_zlib_header(&mut writer, zlib::CompressionLevel::Default)
@@ -197,7 +192,7 @@ pub fn deflate_bytes_zlib_conf<O: Into<CompressionOptions>>(input: &[u8], option
     let hash = checksum.current_hash();
 
     writer
-        .write_u32::<BigEndian>(hash)
+        .write(&hash.to_be_bytes())
         .expect("Write error when writing checksum!");
     writer
 }

--- a/src/stored_block.rs
+++ b/src/stored_block.rs
@@ -1,5 +1,4 @@
 use crate::bitstream::LsbWriter;
-use byteorder::{LittleEndian, WriteBytesExt};
 use std::io;
 use std::io::Write;
 use std::u16;
@@ -33,9 +32,9 @@ pub fn compress_block_stored<W: Write>(input: &[u8], writer: &mut W) -> io::Resu
     };
     // The header is written before this function.
     // The next two bytes indicates the length
-    writer.write_u16::<LittleEndian>(input.len() as u16)?;
+    writer.write(&(input.len() as u16).to_le_bytes())?;
     // the next two after the length is the ones complement of the length
-    writer.write_u16::<LittleEndian>(!input.len() as u16)?;
+    writer.write(&(!input.len() as u16).to_le_bytes())?;
     // After this the data is written directly with no compression
     writer.write(input)
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,8 +1,6 @@
 use std::io::Write;
 use std::{io, thread};
 
-use byteorder::{BigEndian, WriteBytesExt};
-
 use crate::checksum::{Adler32Checksum, RollingChecksum};
 use crate::compress::compress_data_dynamic_n;
 use crate::compress::Flush;
@@ -241,7 +239,9 @@ impl<W: Write> ZlibEncoder<W> {
             .inner
             .as_mut()
             .expect(ERR_STR)
-            .write_u32::<BigEndian>(hash)
+            .write(&hash.to_be_bytes())?;
+
+        Ok(())
     }
 
     /// Return the adler32 checksum of the currently consumed data.


### PR DESCRIPTION
It can easily be replaced with std version. 

Bumps MSRV to 1.32