### PR TITLE
Fix gzip feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,6 @@ pub fn deflate_bytes_gzip_conf<O: Into<CompressionOptions>>(
     options: O,
     gzip_header: GzBuilder,
 ) -> Vec<u8> {
-    use byteorder::WriteBytesExt;
     let mut writer = Vec::with_capacity(input.len() / 3);
 
     // Write header
@@ -259,10 +258,10 @@ pub fn deflate_bytes_gzip_conf<O: Into<CompressionOptions>>(
     crc.update(input);
 
     writer
-        .write_u32::<LittleEndian>(crc.sum())
+        .write(&crc.sum().to_le_bytes())
         .expect("Write error when writing checksum!");
     writer
-        .write_u32::<LittleEndian>(crc.amt_as_u32())
+        .write(&crc.amt_as_u32().to_le_bytes())
         .expect("Write error when writing amt!");
     writer
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -426,7 +426,7 @@ pub mod gzip {
         }
 
         /// Get the crc32 checksum of the data consumed so far.
-        pub const fn checksum(&self) -> u32 {
+        pub fn checksum(&self) -> u32 {
             self.checksum.sum()
         }
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -297,7 +297,6 @@ pub mod gzip {
 
     use super::*;
 
-    use byteorder::{LittleEndian, WriteBytesExt};
     use gzip_header::{Crc, GzBuilder};
 
     /// A Gzip encoder/compressor.
@@ -416,8 +415,8 @@ pub mod gzip {
             // writing fails.
             let mut buf = [0u8; 8];
             let mut temp = Cursor::new(&mut buf[..]);
-            temp.write_u32::<LittleEndian>(crc).unwrap();
-            temp.write_u32::<LittleEndian>(amount).unwrap();
+            temp.write(&crc.to_le_bytes()).unwrap();
+            temp.write(&amount.to_le_bytes()).unwrap();
             self.inner
                 .deflate_state
                 .inner


### PR DESCRIPTION
gzip feature has been broken at least since 0.9.0 release (see for example docs.rs build log https://docs.rs/crate/deflate/0.9.0/builds/340363). This pull request fixes it.